### PR TITLE
Added flag to skip verification of SSL certificate

### DIFF
--- a/src/ephemeris/common_parser.py
+++ b/src/ephemeris/common_parser.py
@@ -41,6 +41,13 @@ def get_common_args(login_required=True, log_file=False):
         help="Target Galaxy instance URL/IP address",
         default="http://localhost:8080",
     )
+    con_group.add_argument(
+        "--skip-verify",
+        "--skip_verify",
+        dest="skip_verify",
+        help="Optional flag to skip verification of SSL Certificate for Galaxy connection. Default value of 'False' when not included in a function call (SSL certificate will be verified). Including the flag in the function call sets the value to 'True' (SSL certificate will NOT be verified).",
+        action="store_true"
+    )
 
     if login_required:
         con_group.add_argument("-u", "--user", help="Galaxy user email address")

--- a/src/ephemeris/get_tool_list_from_galaxy.py
+++ b/src/ephemeris/get_tool_list_from_galaxy.py
@@ -328,6 +328,8 @@ def check_galaxy_version(gi):
 def main():
     options = _parse_cli_options()
     gi = get_galaxy_connection(options, login_required=False)
+    if options.skip_verify:
+        gi.verify = False
     check_galaxy_version(gi)
     gi_to_tool_yaml = GiToToolYaml(
         gi=gi,

--- a/src/ephemeris/install_tool_deps.py
+++ b/src/ephemeris/install_tool_deps.py
@@ -50,6 +50,8 @@ def main():
     """
     args = _parser().parse_args()
     gi = get_galaxy_connection(args)
+    if args.skip_verify:
+        gi.verify = False
     tool_client = ToolClient(gi)
 
     if args.verbose:

--- a/src/ephemeris/run_data_managers.py
+++ b/src/ephemeris/run_data_managers.py
@@ -356,6 +356,8 @@ def main():
     else:
         log.setLevel(logging.INFO)
     gi = get_galaxy_connection(args, file=args.config, log=log, login_required=True)
+    if args.skip_verify:
+        gi.verify = False
     config = load_yaml_file(args.config)
     data_managers = DataManagers(gi, config)
     data_managers.run(log, args.ignore_errors, args.overwrite)

--- a/src/ephemeris/set_library_permissions.py
+++ b/src/ephemeris/set_library_permissions.py
@@ -115,6 +115,9 @@ def main():
         sys.exit(
             "Please specify either a valid Galaxy username/password or an API key."
         )
+        
+    if args.skip_verify:
+        gi.verify = False
 
     if args.verbose:
         log.basicConfig(level=log.DEBUG)

--- a/src/ephemeris/setup_data_libraries.py
+++ b/src/ephemeris/setup_data_libraries.py
@@ -246,7 +246,10 @@ def main():
         sys.exit(
             "Please specify either a valid Galaxy username/password or an API key."
         )
-
+    
+    if args.skip_verify:
+        gi.verify = False
+    
     if args.verbose:
         log.basicConfig(level=log.DEBUG)
 

--- a/src/ephemeris/shed_tools.py
+++ b/src/ephemeris/shed_tools.py
@@ -748,6 +748,10 @@ def main():
     gi = get_galaxy_connection(
         args, file=args.tool_list_file, log=log, login_required=True
     )
+    
+    if args.skip_verify:
+        gi.verify = False
+    
     install_repository_manager = InstallRepositoryManager(gi)
 
     repos = args_to_repos(args)

--- a/src/ephemeris/workflow_install.py
+++ b/src/ephemeris/workflow_install.py
@@ -51,6 +51,9 @@ def main():
     """
     args = _parser().parse_args()
     gi = get_galaxy_connection(args)
+    
+    if args.skip_verify:
+        gi.verify = False
 
     if os.path.isdir(args.workflow_path):
         for file_path in os.listdir(args.workflow_path):


### PR DESCRIPTION
Update to common_parser to include an optional flag to skip verification of the SSL certificate when connecting to a Galaxy instance. Default value of 'False' when not included in a function call (SSL certificate will be verified). Including the flag in the function call sets the value to 'True' (SSL certificate will NOT be verified).

Added check of skip_verify flag to python scripts after the line of main() that makes the Galaxy connections, gi = get_galaxy_connection(). SSL certificate verification is skipped if the skip_verify flag is True (default is False).